### PR TITLE
add new option to publisher --device_mac

### DIFF
--- a/cloudbrain/connectors/ConnectorInterface.py
+++ b/cloudbrain/connectors/ConnectorInterface.py
@@ -8,12 +8,13 @@ class Connector(object):
   
     __metaclass__ = ABCMeta
   
-    def __init__(self, publishers, buffer_size, device_name, device_port):
+    def __init__(self, publishers, buffer_size, device_name, device_port, device_mac):
 
       self.metrics = get_metrics_names(device_name)
       self.device = None
       self.device_port = device_port
       self.device_name = device_name
+      self.device_mac = device_mac
 
       self.buffers = {metric: ConnectorBuffer(buffer_size, publishers[metric].publish) for metric in self.metrics}
       self.publishers = publishers
@@ -27,4 +28,3 @@ class Connector(object):
       """
     
 
-      

--- a/cloudbrain/connectors/MockConnector.py
+++ b/cloudbrain/connectors/MockConnector.py
@@ -8,12 +8,12 @@ from cloudbrain.utils.metadata_info import get_num_channels
 class MockConnector(Connector):
   
   
-  def __init__(self, publishers, buffer_size, device_name, device_port='mock_port'):
+  def __init__(self, publishers, buffer_size, device_name, device_port='mock_port', device_mac=None):
     """
     
     :return:
     """
-    super(MockConnector, self).__init__(publishers, buffer_size, device_name, device_port)
+    super(MockConnector, self).__init__(publishers, buffer_size, device_name, device_port, device_mac)
     self.data_generators = [self.data_generator_factory(metric, get_num_channels(self.device_name, metric)) for metric in self.metrics]
     
     

--- a/cloudbrain/connectors/MuseConnector.py
+++ b/cloudbrain/connectors/MuseConnector.py
@@ -11,7 +11,7 @@ class UnableToStartMuseIO(Exception):
     pass
 
 
-def connect_muse(port=9090):
+def connect_muse(port=9090, mac=None):
     """
     Starts muse-io to pair with a muse.
     @param port (int)
@@ -19,6 +19,8 @@ def connect_muse(port=9090):
 
     """
     cmd = ["muse-io", "--osc", "osc.udp://localhost:%s" %port]
+    if mac != None:
+        cmd.extend(["--device", mac])
 
     print "\nRunning command: %s" %" ".join(cmd)
 
@@ -40,12 +42,12 @@ def connect_muse(port=9090):
 
 
 class MuseConnector(Connector):
-  def __init__(self, publishers, buffer_size, device_name='muse', device_port='9090'):
-    super(MuseConnector, self).__init__(publishers, buffer_size, device_name, device_port)
+  def __init__(self, publishers, buffer_size, device_name='muse', device_port='9090', device_mac=None):
+    super(MuseConnector, self).__init__(publishers, buffer_size, device_name, device_port, device_mac)
 
   def connect_device(self):
 
-    connect_muse(port=self.device_port)
+    connect_muse(port=self.device_port, mac=self.device_mac)
 
     # callback functions to handle the sample for that metric (each metric has a specific number of channels)
     cb_functions = {metric: self.callback_factory(metric, get_num_channels(self.device_name, metric))

--- a/cloudbrain/publishers/sensor_publisher.py
+++ b/cloudbrain/publishers/sensor_publisher.py
@@ -45,6 +45,7 @@ def get_args_parser():
     parser.add_argument('-b', '--buffer_size', default=10,
                         help='Size of the buffer ')
     parser.add_argument('-p', '--device_port', help="Port used for OpenBCI Device.")
+    parser.add_argument('-M', '--device_mac', help="MAC address of device used for Muse connector.")
 
     parser.add_argument('-P', '--publisher', default="pika",
                         help="The subscriber to use to get the data.\n"
@@ -73,6 +74,7 @@ def main():
   device_port = opts.device_port
   pipe_name = opts.output
   publisher = opts.publisher
+  device_mac = opts.device_mac
 
   run(device_name,
       mock_data_enabled,
@@ -81,7 +83,8 @@ def main():
       buffer_size,
       device_port,
       pipe_name,
-      publisher)
+      publisher,
+      device_mac)
 
 
 def run(device_name='muse',
@@ -91,7 +94,8 @@ def run(device_name='muse',
         buffer_size=10,
         device_port='/dev/tty.OpenBCI-DN0094CZ',
         pipe_name=None,
-        publisher_type="pika"):
+        publisher_type="pika",
+        device_mac=None):
   if device_name == 'muse':
     from cloudbrain.connectors.MuseConnector import MuseConnector as Connector
   elif device_name == 'openbci':
@@ -118,7 +122,7 @@ def run(device_name='muse',
   if device_name == 'openbci':
     connector = Connector(publishers, buffer_size, device_name, device_port)
   else:
-    connector = Connector(publishers, buffer_size, device_name)
+    connector = Connector(publishers, buffer_size, device_name, 9090, device_mac)
   connector.connect_device()
 
   if mock_data_enabled and (publisher_type != 'pipe'):


### PR DESCRIPTION
In Linux the Muse capture won't work without manually entering the
bluetooth mac addr. Pass it as an option.