### PR TITLE
RT-SRV-OPT Real Time Server Optimization and Bugfixes

### DIFF
--- a/cloudbrain/rt_server/rt_server.py
+++ b/cloudbrain/rt_server/rt_server.py
@@ -85,14 +85,17 @@ class RtStreamConnection(SockJSConnection):
             self.subscribers[unsubscription_msg['metric']].disconnect()
 
     def on_close(self):
-        logging.info('Disconnecting client, unsubscribing from queues...')
-        for (metric, subscriber) in self.subscribers.keys():
-          if subscriber is not None:
-              subscriber.disconnect()
+        logging.info('Disconnecting client...')
+        for metric in self.subscribers.keys():
+            subscriber = self.subscribers[metric]
+            if subscriber is not None:
+                logging.info('Disconnecting subscriber for metric: ' + metric)
+                subscriber.disconnect()
 
         self.subscribers = {}
         #self.timeout.stop()
         self.clients.remove(self)
+        logging.info('Client disconnection complete!')
 
     def send_heartbeat(self):
         self.broadcast(self.clients, 'message')

--- a/cloudbrain/rt_server/rt_server.py
+++ b/cloudbrain/rt_server/rt_server.py
@@ -141,11 +141,15 @@ class TornadoSubscriber(object):
     def on_connected(self, connection):
         self.connection = connection
         self.connection.add_on_close_callback(self.on_connection_closed)
+        self.connection.add_backpressure_callback(self.on_backpressure_callback)
         self.open_channel()
 
     def on_connection_closed(self, connection, reply_code, reply_text):
         self.connection = None
         self.channel = None
+
+    def on_backpressure_callback(self, connection):
+        logging.info('******** Backpressure detected for ' + self.get_key())
 
     def open_channel(self):
         self.connection.channel(self.on_channel_open)

--- a/cloudbrain/ui/rt-chart/rt-chart.directive.js
+++ b/cloudbrain/ui/rt-chart/rt-chart.directive.js
@@ -5,7 +5,7 @@
     .directive('rtChart', ['$matter', 'RtChart', function($matter, RtChart){
 
       var link = function(scope, element){
-        scope.deviceNames = ['Muse', 'OpenBCI'];
+        scope.deviceNames = ['muse', 'OpenBCI'];
 
         scope.series = RtChart.getSeries();
         scope.data = RtChart.getData();


### PR DESCRIPTION
This PR fixes some issues with the real time server:

* The queues where all bound to the same routing key, that caused conflicts when connecting from different users/devices. Now that's fixed @flysonic10 ;)
* The performance problem on the long run of the rt-server was actually caused by a wrong disconnection logic form multiple subscribers (@marionleborgne arrrrgggghhhhhh!!! :smile:). That's fixed now, but I'm explaining below what was happening because it's tricky and related to our configuration of RabbitMQ and we need to be aware of that for the NY Faire
* In the UI the interface is renamed from `Muse` to `muse` in order to be consistent with RabbitMQ exchanges

-----------------------------------------------

**Performance Issue Demystified**

It was a subtle issue: the main point is that every time we reloaded the page (with the rt-server always active)  resetting the websocket, we weren't actually unsubscribing from RabbitMQ from the rt-server. That was leaving these consumers there. It sounds a memory leak, and it actually is; but that wasn't the primary cause of slowing down.
The main problem is that the exchange/queues on RabbitMQ are consumed in a FIFO fashion, not in a publish/subscribe or topic fashion! That means that the first that get the data-point out will have that data-point, and the other subscribers won't receive that data-point anymore!
Since we were connecting same user same metric multiple times from the UI, we were accumulating subscribers on the rt-server (because we weren't closing the subscription on websocket close) and they were safely splitting the data received. The only subscriber visualized on the UI is the last opened one, and every last subscriber will get less data less frequently because all of them are extracting from Rabbit at the same time!

**IMPORTANT**: We need to not connect from multiple browsers for the same user and same metric, otherwise you split the data between the two sessions! That's what we should do for NY Faire presentation.
Then the solution will be to have exchanges like topics or in a publish/subscribe fashion - and that will solve all our problems and allow multiple sessions and connections also for same user/same metric. :)

THAT'S IT!!! Fiu.......