### PR TITLE
Persist current user after authrocket addition

### DIFF
--- a/cloudbrain/frontend/account/account.controller.js
+++ b/cloudbrain/frontend/account/account.controller.js
@@ -14,7 +14,7 @@
 			.then(function (loginRes){
 				$log.log('Successful login:', loginRes);
 				$scope.data.loading = false;
-				$rootScope.currentUser = $matter.currentUser;
+				$rootScope.currentUser = $matter.currentUser || $scope.data;
 				$rootScope.$digest();
 				$scope.showToast('Logged In');
 				$state.go('rtchart');
@@ -53,6 +53,7 @@
 					$scope.data.loading = false;
 					$log.log('Successful login:', loginRes);
 					$scope.showToast('Logged In');
+					$rootScope.currentUser = $matter.currentUser || $scope.data;
 					$state.go('rtchart');
 				}, function (err){
 					$scope.data.loading = false;

--- a/cloudbrain/frontend/rt-chart/rt-chart.directive.js
+++ b/cloudbrain/frontend/rt-chart/rt-chart.directive.js
@@ -5,6 +5,7 @@
     .directive('rtChart', ['$rootScope', '$interval', '$matter', 'apiService', 'RtChart', function($rootScope, $interval, $matter, apiService, RtChart){
 
       var link = function(scope, element){
+        scope.currentUser = $rootScope.currentUser;
         scope.deviceNames = ['muse', 'openbci'];
         scope.series = RtChart.getSeries();
         scope.data = RtChart.getData();
@@ -17,7 +18,7 @@
             RtChart.stop();
           }else{
             RtChart.setDeviceType(scope.selectedDevice);
-            RtChart.setDeviceId($matter.currentUser.username);
+            RtChart.setDeviceId(scope.currentUser.username);
             RtChart.start();
             $interval(function () {}, 50);
           }

--- a/cloudbrain/frontend/rt-chart/rt-chart.service.js
+++ b/cloudbrain/frontend/rt-chart/rt-chart.service.js
@@ -117,7 +117,9 @@
       }
 
       function stop() {
-        stream.disconnect();
+        if(Object.keys(stream).length) {
+          stream.disconnect();
+        }
       }
 
       return {


### PR DESCRIPTION
Auth backend changes leave $matter without current user information. This commit is a workaround to store user info in the rootScope so that it can be used for the rt-chart.