### PR TITLE
change power_bands to alpha_absolute for rt_server

### DIFF
--- a/cloudbrain/rt_server/mock.html
+++ b/cloudbrain/rt_server/mock.html
@@ -22,10 +22,10 @@
       function onConnect() {
           connected = true;
           rtDataStream.subscribe('eeg', generateLogFn(1));
-          rtDataStream.subscribe('power_bands', generateLogFn(2));
+          rtDataStream.subscribe('alpha_absolute', generateLogFn(2));
           // After 3 seconds you subscribe also to the second metric
           setTimeout(function () {
-              rtDataStream.unsubscribe('power_bands');
+              rtDataStream.unsubscribe('alpha_absolute', generateLogFn(2));
           }, 5000);
           update_ui();
       }

--- a/cloudbrain/rt_server/rt-data-stream.js
+++ b/cloudbrain/rt_server/rt-data-stream.js
@@ -25,7 +25,7 @@ RtDataStream = function (connUrl, deviceName, deviceId) {
     this.conn = null;
     this.channelSubs = {
         'eeg': [],
-        'power_bands': [],
+        'alpha_absolute': [],
     };
 
     // Property definition


### PR DESCRIPTION
@marionleborgne @alessiodm 

power_bands no longer in queue, had to switch to alpha_absolute to test two streams. We should find a nice way to get all channelSubs for device.